### PR TITLE
Fix positioning in administration preview

### DIFF
--- a/src/Resources/app/administration/src/module/rl-advanced-banners/service/default-css-styles.js
+++ b/src/Resources/app/administration/src/module/rl-advanced-banners/service/default-css-styles.js
@@ -1,5 +1,5 @@
 export default function defaultCssStyles(layer) {
-    let styles = '';
+    let styles = 'position: relative;';
     styles += `height: ${layer.config.height};`;
     styles += `width: ${layer.config.width};`;
     styles += `top: ${layer.config.posTop};`;


### PR DESCRIPTION
CSS properties for positioning (top, right, bottom, left) doesn't have an effect in the administration preview